### PR TITLE
feature: devshell

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas": {
+      "version": "7.0.1",
+      "commands": [
+        "fantomas"
+      ],
+      "rollForward": false
+    },
+    "dotnet-fsharplint": {
+      "version": "0.24.2",
+      "commands": [
+        "dotnet-fsharplint"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/Fun/.config/dotnet-tools.json
+++ b/Fun/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "dotnet-fsharplint"
       ],
       "rollForward": false
+    },
+    "fantomas": {
+      "version": "7.0.1",
+      "commands": [
+        "fantomas"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/Fun/.config/dotnet-tools.json
+++ b/Fun/.config/dotnet-tools.json
@@ -2,13 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fantomas": {
-      "version": "7.0.1",
-      "commands": [
-        "fantomas"
-      ],
-      "rollForward": false
-    },
     "dotnet-fsharplint": {
       "version": "0.24.2",
       "commands": [

--- a/Fun/.editorconfig
+++ b/Fun/.editorconfig
@@ -1,0 +1,10 @@
+[*.fs]
+fsharp_space_before_uppercase_invocation = true
+
+# Write a comment by starting the line with a '#'
+[*.{fs,fsx,fsi}]
+fsharp_bar_before_discriminated_union_declaration = true
+
+# Apply specific settings for a targeted subfolder
+[src/Elmish/View.fs]
+fsharp_multiline_bracket_style = stroustrup

--- a/Fun/Fun.fsproj
+++ b/Fun/Fun.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/Fun/Fun.fsproj
+++ b/Fun/Fun.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fun/Program.fs
+++ b/Fun/Program.fs
@@ -1,0 +1,2 @@
+﻿// For more information see https://aka.ms/fsharp-console-apps
+printfn "Hello from F#"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,19 +1,16 @@
 version: '3'
 
-vars:
-  GREETING: Hello, World!
-
 tasks:
   up:
     dir: Fun
     cmds:
       - nix develop
+  build:
+    cmds:
+      - dotnet build
   run:
-    dir: Fun
     cmds:
       - dotnet run
-    silent: true
   lint:
-    dir: Fun
     cmds:
       - dotnet fsharplint lint Fun.fsproj

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+vars:
+  GREETING: Hello, World!
+
+tasks:
+  up:
+    dir: Fun
+    cmds:
+      - nix develop
+  run:
+    dir: Fun
+    cmds:
+      - dotnet run
+    silent: true
+  lint:
+    dir: Fun
+    cmds:
+      - dotnet fsharplint lint Fun.fsproj

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,11 +6,18 @@ tasks:
     cmds:
       - nix develop
   build:
+    dir: Fun
     cmds:
       - dotnet build
   run:
+    dir: Fun
     cmds:
       - dotnet run
   lint:
+    dir: Fun
     cmds:
       - dotnet fsharplint lint Fun.fsproj
+  format:
+    dir: Fun
+    cmds:
+      - dotnet fantomas .

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1744473229,
+        "narHash": "sha256-rGXvIsD/Hn+bJRFb7hqSx7UUZUIlxXs0fM6ix5+iT5w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "52d0eded529af34e91df6b2a2bc32eb636637cd2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
+        "rev": "52d0eded529af34e91df6b2a2bc32eb636637cd2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,10 +12,10 @@
         pkgs = import nixpkgs { inherit system; };
       in {
         devShells.default = pkgs.mkShell {
-          packages = with pkgs; [ dotnet-sdk_9 go-task ];
+          packages = [ pkgs.dotnet-sdk_10 pkgs.go-task ];
 
           shellHook = ''
-            export DOTNET_ROOT=${pkgs.dotnet-sdk_9}
+            export DOTNET_ROOT=${pkgs.dotnet-sdk_10.sdk}
             if [ ! -f .config/dotnet-tools.json ]; then
               dotnet new tool-manifest
               dotnet tool install fantomas

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         pkgs = import nixpkgs { inherit system; };
       in {
         devShells.default = pkgs.mkShell {
-          packages = [ pkgs.dotnet-sdk_9 pkgs.go-task ];
+          packages = [ pkgs.dotnet-sdk_8 pkgs.go-task ];
 
           shellHook = ''
             export DOTNET_ROOT=$(dirname $(readlink -f $(which dotnet)))

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "DevShell for F#";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ dotnet-sdk_9 go-task ];
+
+          shellHook = ''
+            export DOTNET_ROOT=${pkgs.dotnet-sdk_9}
+            if [ ! -f .config/dotnet-tools.json ]; then
+              dotnet new tool-manifest
+              dotnet tool install fantomas
+              dotnet tool install dotnet-fsharplint
+            else
+              dotnet tool restore
+            fi
+          '';
+        };
+      });
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "DevShell for F#";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/52d0eded529af34e91df6b2a2bc32eb636637cd2";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -12,10 +12,10 @@
         pkgs = import nixpkgs { inherit system; };
       in {
         devShells.default = pkgs.mkShell {
-          packages = [ pkgs.dotnet-sdk_10 pkgs.go-task ];
+          packages = [ pkgs.dotnet-sdk_9 pkgs.go-task ];
 
           shellHook = ''
-            export DOTNET_ROOT=${pkgs.dotnet-sdk_10.sdk}
+            export DOTNET_ROOT=$(dirname $(readlink -f $(which dotnet)))
             if [ ! -f .config/dotnet-tools.json ]; then
               dotnet new tool-manifest
               dotnet tool install fantomas


### PR DESCRIPTION
```shell
$ task up
tsuchiyashunsukes-MacBook-Pro:Fun shunsock$ dotnet tool install fantomas
You can invoke the tool from this directory using the following commands: 'dotnet tool run fantomas' or 'dotnet fantomas'.
Tool 'fantomas' (version '7.0.1') was successfully installed. Entry is added to the manifest file /Users/shunsock/hobby/fun/Fun/.config/dotnet-tools.json.
tsuchiyashunsukes-MacBook-Pro:Fun shunsock$ task format
task: [format] dotnet fantomas .
Program.fs was unchanged.
tsuchiyashunsukes-MacBook-Pro:Fun shunsock$ task lint
task: [lint] dotnet fsharplint lint Fun.fsproj
========== Linting /Users/shunsock/hobby/fun/Fun/obj/Debug/net8.0/Fun.AssemblyInfo.fs ==========
========== Finished: 0 warnings ==========
========== Linting /Users/shunsock/hobby/fun/Fun/obj/Debug/net8.0/.NETCoreApp,Version=v8.0.AssemblyAttributes.fs ==========
========== Finished: 0 warnings ==========
========== Linting /Users/shunsock/hobby/fun/Fun/Program.fs ==========
========== Finished: 0 warnings ==========
========== Summary: 0 warnings ==========
tsuchiyashunsukes-MacBook-Pro:Fun shunsock$ task run
task: [run] dotnet run
Hello from F#
tsuchiyashunsukes-MacBook-Pro:Fun shunsock$ exit
exit
```